### PR TITLE
Move test dependency to the correct place

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,8 +11,9 @@
   "elm-version": "0.19.0 <= v <= 0.20.0",
   "dependencies": {
     "elm/core": "1.0.0 <= v < 2.0.0",
-    "elm-community/list-extra": "8.7.0 <= v < 8.8.0",
-    "elm-explorations/test": "1.2.0 <= v < 1.3.0"
+    "elm-community/list-extra": "8.7.0 <= v < 8.8.0"
   },
-  "test-dependencies": {}
+  "test-dependencies": {
+    "elm-explorations/test": "1.2.0 <= v < 1.3.0"
+  }
 }


### PR DESCRIPTION
Currently, this package pollutes anything that pulls it in and forces it to use an out of date version of `elm-explorations/test`.  This makes it a test dependency, as it should be, so that it avoids this problem.